### PR TITLE
issue #32, #33, #34 : fix error on wrong opcode handler 

### DIFF
--- a/src/Rfc6455/MessageHandler/WrongOpcodeHandler.php
+++ b/src/Rfc6455/MessageHandler/WrongOpcodeHandler.php
@@ -27,7 +27,7 @@ class WrongOpcodeHandler implements Rfc6455MessageHandlerInterface
      */
     public function supports(Message $message)
     {
-        return in_array($message->getOpcode(), [3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15]);
+        return in_array($message->getOpcode(), [3, 4, 5, 6, 7, 11, 12, 13, 14, 15]);
     }
 
     /**


### PR DESCRIPTION
pong opcode is supported but it should not because it is not a reserved opcode

it should be fix wtest 2.7,  2.8, 2.9.

![index html case_desc_2_8](https://cloud.githubusercontent.com/assets/1079982/20159749/018efe4a-a6e3-11e6-851a-8de96352d02b.png)
![index html case_desc_2_8-5](https://cloud.githubusercontent.com/assets/1079982/20160053/cf8c060c-a6e4-11e6-989c-af52f3ee40f3.png)
![index html case_desc_2_8-2](https://cloud.githubusercontent.com/assets/1079982/20159747/0186ff74-a6e3-11e6-85da-232ac4539612.png)


