### PR TITLE
Fix #21 #36 #37 #38 #39 #40 by fixing wstest 3.1-6

### DIFF
--- a/src/Rfc6455/Message.php
+++ b/src/Rfc6455/Message.php
@@ -138,4 +138,12 @@ class Message
     {
         return in_array($this->getFirstFrame()->getOpcode(), [Frame::OP_TEXT, Frame::OP_BINARY]);
     }
+
+    /**
+     * @return Frame[]
+     */
+    public function getFrames()
+    {
+        return $this->frames;
+    }
 }

--- a/src/Rfc6455/MessageHandler/RsvCheckFrameHandler.php
+++ b/src/Rfc6455/MessageHandler/RsvCheckFrameHandler.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is a part of Woketo package.
+ *
+ * (c) Nekland <dev@nekland.fr>
+ *
+ * For the full license, take a look to the LICENSE file
+ * on the root directory of this project
+ */
+
+namespace Nekland\Woketo\Rfc6455\MessageHandler;
+
+
+use Nekland\Woketo\Rfc6455\Frame;
+use Nekland\Woketo\Rfc6455\Message;
+use Nekland\Woketo\Rfc6455\MessageProcessor;
+use React\Socket\ConnectionInterface;
+
+class RsvCheckFrameHandler implements Rfc6455MessageHandlerInterface
+{
+    public function supports(Message $message)
+    {
+        foreach ($message->getFrames() as $frame) {
+            if ($frame->getRsv1() || $frame->getRsv2() || $frame->getRsv3()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function process(Message $message, MessageProcessor $messageProcessor, ConnectionInterface $socket)
+    {
+        $messageProcessor->write($messageProcessor->getFrameFactory()->createCloseFrame(Frame::CLOSE_PROTOCOL_ERROR), $socket);
+        $socket->end();
+    }
+}

--- a/src/Server/Websocket.php
+++ b/src/Server/Websocket.php
@@ -15,6 +15,7 @@ use Nekland\Woketo\Http\Request;
 use Nekland\Woketo\Message\MessageHandlerInterface;
 use Nekland\Woketo\Rfc6455\Message;
 use Nekland\Woketo\Rfc6455\MessageHandler\CloseFrameHandler;
+use Nekland\Woketo\Rfc6455\MessageHandler\RsvCheckFrameHandler;
 use Nekland\Woketo\Rfc6455\MessageHandler\WrongOpcodeHandler;
 use Nekland\Woketo\Rfc6455\MessageHandler\PingFrameHandler;
 use Nekland\Woketo\Rfc6455\MessageProcessor;
@@ -136,5 +137,6 @@ class Websocket
         $this->messageProcessor->addHandler(new PingFrameHandler());
         $this->messageProcessor->addHandler(new CloseFrameHandler());
         $this->messageProcessor->addHandler(new WrongOpcodeHandler());
+        $this->messageProcessor->addHandler(new RsvCheckFrameHandler());
     }
 }

--- a/tests/Woketo/Rfc6455/MessageHandler/RsvCheckFrameHandlerTest.php
+++ b/tests/Woketo/Rfc6455/MessageHandler/RsvCheckFrameHandlerTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is a part of Woketo package.
+ *
+ * (c) Nekland <dev@nekland.fr>
+ *
+ * For the full license, take a look to the LICENSE file
+ * on the root directory of this project
+ */
+
+namespace Test\Woketo\Rfc6455;
+
+
+use Nekland\Woketo\Rfc6455\Frame;
+use Nekland\Woketo\Rfc6455\FrameFactory;
+use Nekland\Woketo\Rfc6455\Message;
+use Nekland\Woketo\Rfc6455\MessageHandler\RsvCheckFrameHandler;
+use Nekland\Woketo\Rfc6455\MessageProcessor;
+use Nekland\Woketo\Utils\BitManipulation;
+use Prophecy\Argument;
+use React\Socket\ConnectionInterface;
+
+class RsvCheckFrameHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItCloseFrameOnRsvInvalid()
+    {
+        $frame = new Frame();
+
+        $messageProcessor = $this->prophesize(MessageProcessor::class);
+        $frameFactory = $this->prophesize(FrameFactory::class);
+        $socket = $this->prophesize(ConnectionInterface::class);
+
+        $frameFactory->createCloseFrame(Argument::cetera())->willReturn($frame);
+        $messageProcessor->write(Argument::type(Frame::class), Argument::cetera())->shouldBeCalled();
+        $messageProcessor->getFrameFactory()->willReturn($frameFactory->reveal());
+        $socket->end()->shouldBeCalled();
+
+        // Message with 2 frames
+        // 1. "Hel" normal frame
+        // 2. "lo" frame with RSV 1 = 1
+        $message = new Message();
+        $message->addFrame(new Frame(BitManipulation::hexArrayToString(['01', '03', '48', '65', '6c'])));
+        $message->addFrame(new Frame(BitManipulation::hexArrayToString('c0', '02', '6c', '6f')));
+
+        $handler = new RsvCheckFrameHandler();
+        $this->assertTrue($handler->supports($message));
+        $handler->process($message, $messageProcessor->reveal(), $socket->reveal());
+    }
+
+    public function testItDoesNotCloseWhenNoRsv()
+    {
+        $frame = new Frame();
+
+        $messageProcessor = $this->prophesize(MessageProcessor::class);
+        $frameFactory = $this->prophesize(FrameFactory::class);
+        $socket = $this->prophesize(ConnectionInterface::class);
+
+        $frameFactory->createCloseFrame(Argument::cetera())->willReturn($frame);
+        $messageProcessor->write(Argument::type(Frame::class), Argument::cetera())->shouldNotBeCalled();
+        $messageProcessor->getFrameFactory()->willReturn($frameFactory->reveal());
+        $socket->end()->shouldNotBeCalled();
+
+        // Hello masked frame
+        $message = new Message();
+        $message->addFrame(new Frame(BitManipulation::hexArrayToString('81', '85', '37', 'fa', '21', '3d', '7f', '9f', '4d', '51', '58')));
+
+        $handler = new RsvCheckFrameHandler();
+        $this->assertFalse($handler->supports($message));
+    }
+}

--- a/tests/Woketo/Rfc6455/MessageTest.php
+++ b/tests/Woketo/Rfc6455/MessageTest.php
@@ -62,6 +62,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message = new Message();
 
         $this->assertSame($message->addData($multipleFrameData), BitManipulation::hexArrayToString('81', '85', '37', 'fa', '21', '3d', '7f', '9f', '4d', '51', '58'));
+        $this->assertSame(count($message->getFrames()), 2);
     }
 
     public function testItReturnNothingWhenBufferingWhenAddData()


### PR DESCRIPTION
This adds a new handler that catch non empty RSV frames.
In the future this will not be accurate but for now woketo does not
supports extensions.

![image](https://cloud.githubusercontent.com/assets/972456/20248191/e0b8cd78-a9de-11e6-9572-c5a45836ec4a.png)
![image](https://cloud.githubusercontent.com/assets/972456/20248196/ecf1ab46-a9de-11e6-8d09-01b1e388e984.png)
![image](https://cloud.githubusercontent.com/assets/972456/20248201/f86ed20a-a9de-11e6-9de2-df73742a98f2.png)
