### PR TITLE
Fix wstest 3.7

### DIFF
--- a/src/Exception/Frame/InvalidFrameException.php
+++ b/src/Exception/Frame/InvalidFrameException.php
@@ -10,10 +10,7 @@
 
 namespace Nekland\Woketo\Exception\Frame;
 
-
-use Nekland\Woketo\Exception\WebsocketException;
-
-class InvalidFrameException extends WebsocketException
+class InvalidFrameException extends ProtocolErrorException
 {
 
 }

--- a/src/Rfc6455/MessageHandler/CloseFrameHandler.php
+++ b/src/Rfc6455/MessageHandler/CloseFrameHandler.php
@@ -24,7 +24,15 @@ class CloseFrameHandler implements Rfc6455MessageHandlerInterface
 
     public function process(Message $message, MessageProcessor $messageProcessor, ConnectionInterface $socket)
     {
-        $messageProcessor->write($messageProcessor->getFrameFactory()->createCloseFrame(), $socket);
+        $code = Frame::CLOSE_NORMAL;
+
+        foreach ($message->getFrames() as $frame) {
+            if ($frame->getRsv1() || $frame->getRsv2() || $frame->getRsv3()) {
+                $code = Frame::CLOSE_PROTOCOL_ERROR;
+            }
+        }
+
+        $messageProcessor->write($messageProcessor->getFrameFactory()->createCloseFrame($code), $socket);
         $socket->end();
     }
 }

--- a/src/Rfc6455/MessageHandler/CloseFrameHandler.php
+++ b/src/Rfc6455/MessageHandler/CloseFrameHandler.php
@@ -26,10 +26,9 @@ class CloseFrameHandler implements Rfc6455MessageHandlerInterface
     {
         $code = Frame::CLOSE_NORMAL;
 
-        foreach ($message->getFrames() as $frame) {
-            if ($frame->getRsv1() || $frame->getRsv2() || $frame->getRsv3()) {
-                $code = Frame::CLOSE_PROTOCOL_ERROR;
-            }
+        $frame = $message->getFirstFrame();
+        if ($frame->getRsv1() || $frame->getRsv2() || $frame->getRsv3()) {
+            $code = Frame::CLOSE_PROTOCOL_ERROR;
         }
 
         $messageProcessor->write($messageProcessor->getFrameFactory()->createCloseFrame($code), $socket);


### PR DESCRIPTION
Now the close message handler can detect wrong close frames.

Fixes #41 

Non regression proof:

![image](https://cloud.githubusercontent.com/assets/972456/20248481/4852a5b6-a9e5-11e6-93f6-8a5c082179c3.png)
![image](https://cloud.githubusercontent.com/assets/972456/20248484/52563b22-a9e5-11e6-8c44-977366949516.png)
![image](https://cloud.githubusercontent.com/assets/972456/20248570/35f18b6a-a9e7-11e6-8953-68881b5bd24d.png)

it also fixes 5.1 & 5.2
