### PR TITLE
Make almost all 6.x green

### DIFF
--- a/src/Rfc6455/Frame.php
+++ b/src/Rfc6455/Frame.php
@@ -16,7 +16,6 @@ use Nekland\Woketo\Exception\Frame\IncompleteFrameException;
 use Nekland\Woketo\Exception\Frame\InvalidFrameException;
 use Nekland\Woketo\Exception\Frame\TooBigControlFrameException;
 use Nekland\Woketo\Exception\Frame\TooBigFrameException;
-use Nekland\Woketo\Exception\Frame\WrongEncodingException;
 use Nekland\Woketo\Utils\BitManipulation;
 
 /**
@@ -505,14 +504,9 @@ class Frame
      *
      * @throws ControlFrameException
      * @throws TooBigControlFrameException
-     * @throws WrongEncodingException
      */
     public static function checkFrame(Frame $frame)
     {
-        if ($frame->getOpcode() === Frame::OP_TEXT && !mb_check_encoding($frame->getPayload(), 'UTF-8')) {
-            throw new WrongEncodingException('The text is not encoded in UTF-8.');
-        }
-
         if ($frame->isControlFrame()) {
             if (!$frame->isFinal()) {
                 throw new ControlFrameException('The frame cannot be fragmented');

--- a/src/Rfc6455/Message.php
+++ b/src/Rfc6455/Message.php
@@ -11,11 +11,13 @@
 namespace Nekland\Woketo\Rfc6455;
 
 use Nekland\Tools\StringTools;
+use Nekland\Woketo\Exception\Frame\WrongEncodingException;
 use Nekland\Woketo\Exception\LimitationException;
 use Nekland\Woketo\Exception\MissingDataException;
 
 class Message
 {
+    const MAX_MESSAGES_BUFFERING = 1000;
     /**
      * @var array
      */
@@ -84,6 +86,7 @@ class Message
      * @return Message
      * @throws \InvalidArgumentException
      * @throws LimitationException
+     * @throws WrongEncodingException
      */
     public function addFrame(Frame $frame) : Message
     {
@@ -91,12 +94,18 @@ class Message
             throw new \InvalidArgumentException('The message is already complete.');
         }
 
-        if (count($this->frames) > 19) {
+        if (count($this->frames) > Message::MAX_MESSAGES_BUFFERING) {
             throw new LimitationException('We don\'t accept more than 20 frames by message. This is a security limitation.');
         }
 
         $this->isComplete = $frame->isFinal();
         $this->frames[] = $frame;
+
+        if ($this->isComplete()) {
+            if ($this->getFirstFrame()->getOpcode() === Frame::OP_TEXT && !mb_check_encoding($this->getContent(), 'UTF-8')) {
+                throw new WrongEncodingException('The text is not encoded in UTF-8.');
+            }
+        }
 
         return $this;
     }

--- a/src/Rfc6455/Message.php
+++ b/src/Rfc6455/Message.php
@@ -95,7 +95,9 @@ class Message
         }
 
         if (count($this->frames) > Message::MAX_MESSAGES_BUFFERING) {
-            throw new LimitationException('We don\'t accept more than 20 frames by message. This is a security limitation.');
+            throw new LimitationException(
+                sprintf('We don\'t accept more than %s frames by message. This is a security limitation.', Message::MAX_MESSAGES_BUFFERING)
+            );
         }
 
         $this->isComplete = $frame->isFinal();

--- a/tests/Woketo/Rfc6455/FrameTest.php
+++ b/tests/Woketo/Rfc6455/FrameTest.php
@@ -14,7 +14,6 @@ namespace Test\Woketo\Rfc6455;
 use Nekland\Woketo\Exception\Frame\ControlFrameException;
 use Nekland\Woketo\Exception\Frame\IncompleteFrameException;
 use Nekland\Woketo\Exception\Frame\TooBigControlFrameException;
-use Nekland\Woketo\Exception\Frame\WrongEncodingException;
 use Nekland\Woketo\Rfc6455\Frame;
 use Nekland\Woketo\Utils\BitManipulation;
 
@@ -222,15 +221,6 @@ class FrameTest extends \PHPUnit_Framework_TestCase
     public function testItChecksAGoodControlFrame()
     {
         $frame = BitManipulation::hexArrayToString(['89','88','b5','c7','6d','58','b5','38','93','a5','49','3c','6d','a7']);
-        $frame = new Frame($frame);
-        Frame::checkFrame($frame);
-    }
-
-    public function testItThrowsWrongEncoding()
-    {
-        $this->expectException(WrongEncodingException::class);
-
-        $frame = BitManipulation::hexArrayToString(['81','94','e8','e7','96','54','26','5d','77','e9','51','28','15','9a','54','29','23','b9','48','67','f3','30','81','93','f3','30']);
         $frame = new Frame($frame);
         Frame::checkFrame($frame);
     }


### PR DESCRIPTION
The point is to fix 6.x tests. It's done by supporting more messages. Limit is now 1000.

Only 6.4.x doesn't pass. It fixes #72 #73

![image](https://cloud.githubusercontent.com/assets/972456/20653557/9c132470-b50f-11e6-800d-f8a3fc206a15.png)