### PR TITLE
fix client

### DIFF
--- a/tests/client_autobahn.php
+++ b/tests/client_autobahn.php
@@ -1,6 +1,6 @@
 <?php
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 /**
  * Usage:


### PR DESCRIPTION
In the doc, we can read:

> Client test suite
> 
> wstest -m fuzzingserver
> php tests/client_autobahn.php

This fixes this errors.

>  -  ~  -  Woketo  php tests/client_autobahn.php 
> PHP Warning:  require(../vendor/autoload.php): failed to open stream: No such file or directory in /-/-/-/Woketo/tests/client_autobahn.php on line 3
> PHP Fatal error:  require(): Failed opening required '../vendor/autoload.php' (include_path='.:/usr/share/pear:/usr/share/php') in /-/-/-/Woketo/tests/client_autobahn.php on line 3
