### PR TITLE
Add getter for event loop

### DIFF
--- a/src/Core/AbstractConnection.php
+++ b/src/Core/AbstractConnection.php
@@ -165,6 +165,14 @@ abstract class AbstractConnection
     }
 
     /**
+     * @return LoopInterface
+     */
+    public function getLoop(): LoopInterface
+    {
+        return $this->loop;
+    }
+
+    /**
      * @param string|Frame  $frame
      * @param int           $opCode
      * @throws \Nekland\Woketo\Exception\RuntimeException


### PR DESCRIPTION
Problem
-----------

The user can stop Woketo but cannot stop the loop if the loop is the one managed by Woketo itself.

Solution
-----------
This PR adds a new getter to retrieve the loop from the connection object. This allows the user to stop entirely Woketo.