### PR TITLE
Fix issue when disconnection occurs before WS handshake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
 
 matrix:
     include:
-        - php: 7.1
+        - php: 7.2
           env: 'COMPOSER_FLAGS="--prefer-lowest --prefer-stable"'
 
 branches:
@@ -20,5 +21,5 @@ script:
     - ./bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
 
 after_script:
-    - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-    - if [ "$TRAVIS_PHP_VERSION" == "7.0" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "7.2" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+    - if [ "$TRAVIS_PHP_VERSION" == "7.2" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/src/Core/AbstractConnection.php
+++ b/src/Core/AbstractConnection.php
@@ -20,6 +20,7 @@ use Nekland\Woketo\Rfc6455\Message;
 use Nekland\Woketo\Rfc6455\MessageProcessor;
 use Nekland\Woketo\Utils\SimpleLogger;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
 use React\Socket\ConnectionInterface;
@@ -59,7 +60,7 @@ abstract class AbstractConnection
     protected $uri;
 
     /**
-     * @var MessageHandlerInterface|\Closure
+     * @var MessageHandlerInterface|callable
      */
     protected $handler;
 
@@ -83,6 +84,7 @@ abstract class AbstractConnection
         $this->handshake = $handshake;
         $this->messageProcessor = $messageProcessor;
         $this->loop = $loop;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -140,7 +142,7 @@ abstract class AbstractConnection
      */
     protected function getHandler() : MessageHandlerInterface
     {
-        if ($this->handler instanceof \Closure) {
+        if (!$this->handler instanceof MessageHandlerInterface) {
             $handler = $this->handler;
             $handler = $handler($this->uri, $this);
 

--- a/src/Server/Connection.php
+++ b/src/Server/Connection.php
@@ -27,7 +27,7 @@ class Connection extends AbstractConnection
 {
     public function __construct(
         ConnectionInterface $socketStream,
-        \Closure $messageHandler,
+        callable $messageHandler,
         LoopInterface $loop,
         MessageProcessor $messageProcessor,
         ServerHandshake $handshake = null
@@ -44,6 +44,10 @@ class Connection extends AbstractConnection
             $this->processData($data);
         });
         $this->stream->once('end', function() {
+            if (!$this->handshakeDone) {
+                $this->logger->info('Disconnected but websocket didn\'t start.');
+                return;
+            }
             $this->getHandler()->onDisconnect($this);
         });
         $this->stream->on('error', function ($data) {

--- a/tests/javascript/js_browser_wss/server.php
+++ b/tests/javascript/js_browser_wss/server.php
@@ -2,6 +2,8 @@
 
 require __DIR__ . '/../../../vendor/autoload.php';
 
+use Nekland\Woketo\Core\AbstractConnection;
+
 $foo = new \Nekland\Woketo\Server\WebSocketServer(9001, '127.0.0.1', [
     'prod' => false,
     'ssl' => true,
@@ -14,23 +16,28 @@ $foo = new \Nekland\Woketo\Server\WebSocketServer(9001, '127.0.0.1', [
 
 class EchoServer implements \Nekland\Woketo\Message\MessageHandlerInterface
 {
-    public function onConnection(\Nekland\Woketo\Server\Connection $connection)
+    public function onConnection(AbstractConnection $connection)
     {
     }
 
-    public function onMessage(string $data, \Nekland\Woketo\Server\Connection $connection)
+    public function onMessage(string $data, AbstractConnection $connection)
     {
         $connection->write($data);
     }
 
-    public function onBinary(string $data, \Nekland\Woketo\Server\Connection $connection)
+    public function onBinary(string $data, AbstractConnection $connection)
     {
         $connection->write($data, \Nekland\Woketo\Rfc6455\Frame::OP_BINARY);
     }
 
-    public function onError(\Nekland\Woketo\Exception\WebsocketException $e, \Nekland\Woketo\Server\Connection $connection)
+    public function onError(\Nekland\Woketo\Exception\WebsocketException $e, AbstractConnection $connection)
     {
         echo '(' . get_class($e) . ') ' . $e->getMessage() . "\n";
+    }
+
+    public function onDisconnect(AbstractConnection $connection)
+    {
+        // Doing nothing
     }
 }
 


### PR DESCRIPTION
When you disconnect from woketo and the handshake is not done, then
woketo can't know what WS handler to call leading to an error. In
this commit I disable handler retrieval if the handshake is not done.

This also adds a little log message.

Fix #149 

It also fixes an old test that was not doing things as expected.