### PR TITLE
PHP8 update - incomplete

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,88 @@
+name: Test suite
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+    schedule:
+        - cron:  '0 0 * * *'
+
+jobs:
+    unit-test:
+        name: Unit tests
+        strategy:
+            matrix:
+                php: [ 7.4, 8.0 ]
+                os: [ ubuntu-latest ]
+                include:
+                    -   os: [ ubuntu-latest ]
+                        php: 8.1
+                        composer-flag: "'--ignore-platform-reqs'"
+
+                    -   os: [ ubuntu-latest ]
+                        php: 7.3
+                        composer-flag: "'--prefer-lowest'"
+
+        runs-on: ${{ matrix.os }}
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+
+            -   uses: actions/cache@v2
+                id: cache-composer
+                with:
+                    path: ~/.composer/cache
+                    key: composer-php-${{ matrix.php }}-${{ github.sha }}
+                    restore-keys: composer-php-${{ matrix.php }}-
+
+            -   name: Install dependencies
+                run: composer update --prefer-dist --no-progress --no-suggest ${{ matrix.composer-flag }}
+
+            # This part is commented for now but let's how being able to uncomment it soon!
+#            -   name: Run PHP CS Fixer
+#                run: make test.phpcs
+
+            -   name: Run PHPUnit tests
+                run: make test.phpunit
+
+    functional-test:
+        name: Functionnal tests
+        strategy:
+            matrix:
+                php: [ 7.4, 8.0 ]
+                os: [ ubuntu-latest ]
+                include:
+                    -   os: [ ubuntu-latest ]
+                        php: 8.1
+                        composer-flag: "'--ignore-platform-reqs'"
+
+                    -   os: [ ubuntu-latest ]
+                        php: 7.3
+                        composer-flag: "'--prefer-lowest'"
+
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+
+            -   uses: actions/cache@v2
+                id: cache-composer
+                with:
+                    path: ~/.composer/cache
+                    key: composer-php-${{ matrix.php }}-${{ github.sha }}
+                    restore-keys: composer-php-${{ matrix.php }}-
+
+
+            -   name: Install dependencies
+                run: composer update --prefer-dist --no-progress --no-suggest ${{ matrix.composer-flag }}
+
+            -   name: Run Behat tests
+                run: make test.behat

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+.DEFAULT_GOAL := help
+COMPOSER   = composer
+
+#
+### PROJECT
+# --------
+#
+
+install: ## Install the project
+	${COMPOSER} install
+.PHONY: install
+
+reset: clean install ## Stop and start a fresh install of the project
+.PHONY: reset
+
+clean: ## Stop the project and remove generated files
+	rm -rf vendor
+.PHONY: clean
+
+#
+### TESTS
+# -------
+#
+
+test: test.composer test.phpcs test.phpunit ## Run all tests
+.PHONY: test
+
+test.composer: ## Validate composer.json
+	composer validate
+
+test.phpcs: ## Run PHP CS Fixer in dry-run
+	composer run -- phpcs --dry-run -v
+
+test.phpcs.fix: ## Run PHP CS Fixer and fix issues if possible
+	composer run -- phpcs -v
+
+test.phpunit: ## Run PHPUnit tests
+	composer run tests
+
+#
+### OTHERS
+# --------
+#
+
+help: SHELL=/bin/bash
+help: ## Dislay this help
+	@IFS=$$'\n'; for line in `grep -h -E '^[a-zA-Z_#-]+:?.*?## .*$$' $(MAKEFILE_LIST)`; do if [ "$${line:0:2}" = "##" ]; then \
+	echo $$line | awk 'BEGIN {FS = "## "}; {printf "\n\033[33m%s\033[0m\n", $$2}'; else \
+	echo $$line | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'; fi; \
+	done; unset IFS;
+.PHONY: help

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "license": "MIT",
     "type": "library",
     "description": "A WebSocket library for PHP",
+    "scripts": {
+        "tests": "phpunit"
+    },
     "autoload": {
         "psr-4": {
             "Nekland\\Woketo\\": "src/"
@@ -14,7 +17,7 @@
         }
     },
     "require": {
-        "php": "^7.0",
+        "php": ">=7.0",
         "react/event-loop": "^1.0.0",
         "react/socket": "^1.0.0",
         "nekland/tools": "^1.0 || ^2.0",

--- a/src/Rfc6455/Handshake/ServerHandshake.php
+++ b/src/Rfc6455/Handshake/ServerHandshake.php
@@ -38,7 +38,7 @@ class ServerHandshake implements HandshakeInterface
 
     /**
      * https://tools.ietf.org/html/rfc6455#section-4.2
-     * 
+     *
      * @param AbstractHttpMessage $request
      * @param string|null         $key
      * @return bool
@@ -62,7 +62,7 @@ class ServerHandshake implements HandshakeInterface
 
         if ($request->getMethod() !== 'GET') {
             throw new WebsocketException(
-                \sprintf('Wrong http method, GET expected, "%" received.', $request->getMethod())
+                \sprintf('Wrong http method, GET expected, "%s" received.', $request->getMethod())
             );
         }
 

--- a/src/Server/Connection.php
+++ b/src/Server/Connection.php
@@ -25,6 +25,11 @@ use React\Socket\ConnectionInterface;
 
 class Connection extends AbstractConnection
 {
+    /**
+     * @var string
+     */
+    private $ip;
+
     public function __construct(
         ConnectionInterface $socketStream,
         callable $messageHandler,
@@ -36,6 +41,7 @@ class Connection extends AbstractConnection
         $this->stream = $socketStream;
         $this->initListeners();
         $this->handler = $messageHandler;
+        $this->ip = $this->stream->getRemoteAddress();
     }
 
     private function initListeners()
@@ -158,6 +164,6 @@ class Connection extends AbstractConnection
      */
     public function getIp()
     {
-        return $this->stream->getRemoteAddress();
+        return $this->ip;
     }
 }

--- a/src/Server/WebSocketServer.php
+++ b/src/Server/WebSocketServer.php
@@ -177,8 +177,8 @@ class WebSocketServer
      */
     private function onDisconnect(Connection $connection)
     {
-        $this->removeConnection($connection);
         $connection->getLogger()->info(sprintf('Ip "%s" left connection', $connection->getIp()));
+        $this->removeConnection($connection);
     }
 
     /**


### PR DESCRIPTION
This PR contains some fixes for a PHP 8 update.

By testing it against the test suite of autobahn, it appears that this is not sufficient to make Woketo fully compatible with PHP 8.

Some problems may be related to the React dependency (it seems that it buffer overflows in big amount of data, something like that...).

Fixing everything for PHP 8 may be demanding in term of time, for a project barely nobody uses.

It was very interesting to build it. Pushing it to be a complete thing working for all situations. I even did a project inside a docker with behat tests and all of this was working great. But it seems to be old times. I guess it's goodbye.